### PR TITLE
ci: publish build-workflow v0.1.22 producer gate

### DIFF
--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.20
+      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.22
     outputs:
       unit_test_files: ${{ steps.quality-metrics.outputs.unit_test_files }}
       unit_test_assertions: ${{ steps.quality-metrics.outputs.unit_test_assertions }}
@@ -109,7 +109,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.20
+          ref: v0.1.22
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Restore Helm caches

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.20
+          ref: v0.1.22
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect changed paths
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.20
+    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.22
 
   validate-app:
     if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.20
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.22
     with:
       chart_path: .
       kubernetes_version: '1.30.0'
@@ -102,7 +102,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.20
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.22
     with:
       chart_path: libChart
       kubernetes_version: '1.30.0'
@@ -124,7 +124,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.20
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.22
     with:
       chart_path: test-chart
       kubernetes_version: '1.30.0'
@@ -146,7 +146,7 @@ jobs:
     if: needs.detect-changes.outputs.run_renovate_validation == 'true'
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.20
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.22
 
   ci-required:
     name: ci-required

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.20
+          ref: v0.1.22
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Build pinned validation image

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -21,7 +21,7 @@ permissions:
   packages: read
 
 concurrency:
-  group: renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
+  group: reusable-renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -57,7 +57,9 @@ jobs:
       - name: Build pinned validation image
         run: make docker-build BUILD_WORKFLOW=.build-workflow DOCKER_IMAGE=helm-validate:renovate
 
-      - name: Regenerate snapshots
+      - name: Regenerate render-only snapshots
+        # This workflow refreshes render artifacts only. Install-time smoke
+        # remains a separate validation gap until a ct install-class gate exists.
         run: make snapshot-update BUILD_WORKFLOW=.build-workflow DOCKER_IMAGE=helm-validate:renovate
 
       - name: Commit updated snapshots

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@ lint-tools-check:
 	fi
 
 lint: lint-tools-check
-	@mapfile -t script_files < <(find scripts -type f -name '*.sh'); \
-	if [ "$${#script_files[@]}" -gt 0 ]; then \
-		shellcheck "$${script_files[@]}"; \
+	@script_files="$$(find scripts -type f -name '*.sh')"; \
+	if [ -n "$$script_files" ]; then \
+		shellcheck $$script_files; \
 	else \
 		echo "No shell scripts found under scripts/"; \
 	fi

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -1,6 +1,6 @@
 # Build-Workflow Trigger Matrix
 
-Last updated: 2026-02-25
+Last updated: 2026-04-30
 Repository: `orhayoun-eevee/build-workflow`
 
 ## Scope and terms
@@ -96,6 +96,18 @@ Why it exists: publish `helm-validate` tool image.
 | `release-chart.yaml` | `release` | Only when called; expects tag context in caller for version/tag check. |
 | `pr-required-checks-chart.yaml` | `detect-changes`, `dependency-review`, `validate-*`, `renovate-config-validation`, `ci-required` | Only when chart repos call it; executes chart-specific required-check orchestration. |
 | `renovate-snapshot-update.yaml` | `update-snapshots` | Only when called in PR context and actor+PR author are `renovate[bot]` from same repo. |
+
+## Consumer Caller Contract Notes
+
+### App-chart `renovate-snapshot-update.yaml` wrapper
+
+- Trigger: `pull_request` `opened`, `synchronize`, and `reopened` events in app-chart repos.
+- Render-input path filter: `Chart.yaml`, `Chart.lock`, `values.yaml`, `templates/**`, `charts/**`, and `tests/scenarios/**`.
+- Deliberate exclusion: `tests/snapshots/**` is excluded so the bot does not retrigger itself after committing refreshed snapshots.
+- Concurrency contract: the caller wrapper and reusable workflow use distinct group prefixes so the reusable run cannot cancel its caller.
+- Validation scope: snapshot refresh proves render drift only. It does not provide install-time smoke.
+- Explicit remaining gap: no `ct install`-class smoke gate exists as of 2026-04-30. Owner: `build-workflow` maintainer.
+- Manual gate until closed: release or rollout evidence must keep this install-smoke gap explicit and must not claim install confidence from `ct lint` or snapshot refresh alone.
 
 ## PR vs Merge vs Tag: Practical Summary
 

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -103,7 +103,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.20` | `docker-build` only (unless manually dispatching others). |
+| Push tag like `v0.1.22` | `docker-build` only (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.

--- a/scripts/detect-required-checks.sh
+++ b/scripts/detect-required-checks.sh
@@ -50,8 +50,9 @@ if [[ "${MODE}" == "build" ]]; then
 	run_renovate_validation=false
 	run_codeql=false
 	run_dependency_review=false
+	guardrail_paths_pattern='^(scripts/|\.github/workflows/|templates/|configs/|docker/Dockerfile)'
 
-	if grep -Eq '^(scripts/|\.github/workflows/|docker/Dockerfile)' <<<"${changed_files}"; then
+	if grep -Eq "${guardrail_paths_pattern}" <<<"${changed_files}"; then
 		run_guardrails=true
 	fi
 

--- a/scripts/test-detect-required-checks.sh
+++ b/scripts/test-detect-required-checks.sh
@@ -24,6 +24,7 @@ mkdir -p "${repo}"
 	git init -q
 	git config user.name "ci"
 	git config user.email "ci@example.com"
+	git config commit.gpgsign false
 	mkdir -p scripts .github/workflows templates
 	cat >scripts/a.sh <<'EOF'
 #!/usr/bin/env bash
@@ -75,6 +76,36 @@ EOF
 	: >"${out}"
 	MODE=build EVENT_NAME=pull_request BASE_SHA="${head_sha}" HEAD_SHA="${head_sha_docs}" GITHUB_OUTPUT="${out}" "${DETECT_SCRIPT}"
 	assert_contains "${out}" "run_guardrails=false"
+	assert_contains "${out}" "run_docker_smoke=false"
+	assert_contains "${out}" "run_renovate_validation=false"
+	assert_contains "${out}" "run_codeql=false"
+	assert_contains "${out}" "run_dependency_review=false"
+
+	mkdir -p templates/app-chart/.github/workflows
+	echo "name: template contract" >templates/app-chart/.github/workflows/pr-required-checks.yaml
+	git add templates/app-chart/.github/workflows/pr-required-checks.yaml
+	git commit -q -m "template workflow change"
+	head_sha_template="$(git rev-parse HEAD)"
+
+	out="${tmpdir}/build-templates-pr.out"
+	: >"${out}"
+	MODE=build EVENT_NAME=pull_request BASE_SHA="${head_sha_docs}" HEAD_SHA="${head_sha_template}" GITHUB_OUTPUT="${out}" "${DETECT_SCRIPT}"
+	assert_contains "${out}" "run_guardrails=true"
+	assert_contains "${out}" "run_docker_smoke=false"
+	assert_contains "${out}" "run_renovate_validation=false"
+	assert_contains "${out}" "run_codeql=false"
+	assert_contains "${out}" "run_dependency_review=false"
+
+	mkdir -p configs
+	echo "chart-dirs: []" >configs/ct-default.yaml
+	git add configs/ct-default.yaml
+	git commit -q -m "config change"
+	head_sha_config="$(git rev-parse HEAD)"
+
+	out="${tmpdir}/build-configs-pr.out"
+	: >"${out}"
+	MODE=build EVENT_NAME=pull_request BASE_SHA="${head_sha_template}" HEAD_SHA="${head_sha_config}" GITHUB_OUTPUT="${out}" "${DETECT_SCRIPT}"
+	assert_contains "${out}" "run_guardrails=true"
 	assert_contains "${out}" "run_docker_smoke=false"
 	assert_contains "${out}" "run_renovate_validation=false"
 	assert_contains "${out}" "run_codeql=false"

--- a/templates/app-chart/.github/workflows/renovate-snapshot-update.yaml
+++ b/templates/app-chart/.github/workflows/renovate-snapshot-update.yaml
@@ -4,14 +4,21 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
     paths:
+      # Keep the trigger on render inputs only. `tests/snapshots/**` stays out
+      # of scope so the bot does not retrigger itself after committing updates.
+      - "Chart.yaml"
+      - "Chart.lock"
       - "values.yaml"
+      - "templates/**"
+      - "charts/**"
+      - "tests/scenarios/**"
 
 permissions:
   contents: write
   packages: read
 
 concurrency:
-  group: renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
+  group: caller-renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- align build-workflow self references to v0.1.22
- cover templates/** and configs/** in required-check detection
- widen renovate snapshot trigger coverage and document install-smoke deferral

## Validation
- make lint
- scripts/test-detect-required-checks.sh

## Rollout note
This PR is the producer-gate prerequisite for the downstream Helm ref wave.