### PR TITLE
ci: add chart install smoke gate

### DIFF
--- a/.github/workflows/helm-install-smoke.yaml
+++ b/.github/workflows/helm-install-smoke.yaml
@@ -1,0 +1,113 @@
+name: Helm Install Smoke
+
+on:
+  workflow_call:
+    inputs:
+      chart_path:
+        description: 'Path to the Helm chart directory'
+        required: true
+        type: string
+      values_file:
+        description: 'Path to the minimal install values file (repo-relative)'
+        required: true
+        type: string
+      kubernetes_version:
+        description: 'Kubernetes version used for kubectl compatibility checks'
+        required: true
+        type: string
+      kind_node_image:
+        description: 'Pinned kind node image (include digest)'
+        required: true
+        type: string
+    secrets:
+      gh_app_id:
+        description: 'GitHub App ID for minting installation token'
+        required: true
+      gh_app_private_key:
+        description: 'GitHub App private key for minting installation token'
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: helm-install-smoke-${{ github.workflow }}-${{ github.ref }}-${{ inputs.chart_path }}
+  cancel-in-progress: true
+
+jobs:
+  install-smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    env:
+      HELM_VERSION: 3.20.0
+      KIND_VERSION: 0.31.0
+      KUBECTL_VERSION: ${{ inputs.kubernetes_version }}
+      KIND_CLUSTER_NAME: install-smoke
+      KIND_NODE_IMAGE: ${{ inputs.kind_node_image }}
+      CHART_PATH: ${{ inputs.chart_path }}
+      VALUES_FILE: ${{ inputs.values_file }}
+      SMOKE_RELEASE_NAME: install-smoke
+      SMOKE_NAMESPACE: install-smoke
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Mint app token for cross-repo checkout
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.gh_app_id }}
+          private-key: ${{ secrets.gh_app_private_key }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout build-workflow helpers
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: orhayoun-eevee/build-workflow
+          path: .build-workflow
+          ref: v0.1.23
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Install install-smoke toolchain
+        shell: bash
+        run: |
+          set -euo pipefail
+          .build-workflow/scripts/setup-install-smoke-tools.sh
+
+      - name: Create kind cluster
+        shell: bash
+        run: |
+          set -euo pipefail
+          kind create cluster \
+            --name "${KIND_CLUSTER_NAME}" \
+            --image "${KIND_NODE_IMAGE}" \
+            --wait 120s
+          kubectl cluster-info
+          kubectl wait --for=condition=Ready node --all --timeout=180s
+
+      - name: Run install smoke
+        shell: bash
+        run: |
+          set -euo pipefail
+          .build-workflow/scripts/run-install-smoke.sh
+
+      - name: Capture cluster diagnostics
+        if: failure()
+        shell: bash
+        run: |
+          set -euo pipefail
+          kubectl get nodes -o wide || true
+          kubectl get all -A || true
+          kubectl get pvc -A || true
+          kubectl get events -A --sort-by=.metadata.creationTimestamp || true
+
+      - name: Delete kind cluster
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          kind delete cluster --name "${KIND_CLUSTER_NAME}"

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.22
+      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.23
     outputs:
       unit_test_files: ${{ steps.quality-metrics.outputs.unit_test_files }}
       unit_test_assertions: ${{ steps.quality-metrics.outputs.unit_test_assertions }}
@@ -109,7 +109,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.22
+          ref: v0.1.23
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Restore Helm caches

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.22
+          ref: v0.1.23
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect changed paths
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.22
+    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.23
 
   validate-app:
     if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.22
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.23
     with:
       chart_path: .
       kubernetes_version: '1.30.0'
@@ -96,13 +96,30 @@ jobs:
       gh_app_id: ${{ secrets.gh_app_id }}
       gh_app_private_key: ${{ secrets.gh_app_private_key }}
 
+  install-smoke-app:
+    if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
+    needs:
+      - detect-changes
+      - validate-app
+    permissions:
+      contents: read
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.23
+    with:
+      chart_path: .
+      values_file: tests/scenarios/minimal.yaml
+      kubernetes_version: '1.30.0'
+      kind_node_image: 'kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e'
+    secrets:
+      gh_app_id: ${{ secrets.gh_app_id }}
+      gh_app_private_key: ${{ secrets.gh_app_private_key }}
+
   validate-lib:
     if: inputs.chart_kind == 'lib' && needs.detect-changes.outputs.run_validate == 'true'
     needs: detect-changes
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.22
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.23
     with:
       chart_path: libChart
       kubernetes_version: '1.30.0'
@@ -124,7 +141,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.22
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.23
     with:
       chart_path: test-chart
       kubernetes_version: '1.30.0'
@@ -141,12 +158,29 @@ jobs:
       gh_app_id: ${{ secrets.gh_app_id }}
       gh_app_private_key: ${{ secrets.gh_app_private_key }}
 
+  install-smoke-lib:
+    if: inputs.chart_kind == 'lib' && needs.detect-changes.outputs.run_validate == 'true'
+    needs:
+      - detect-changes
+      - validate-test
+    permissions:
+      contents: read
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.23
+    with:
+      chart_path: test-chart
+      values_file: tests/scenarios/minimal.yaml
+      kubernetes_version: '1.30.0'
+      kind_node_image: 'kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e'
+    secrets:
+      gh_app_id: ${{ secrets.gh_app_id }}
+      gh_app_private_key: ${{ secrets.gh_app_private_key }}
+
   renovate-config-validation:
     needs: detect-changes
     if: needs.detect-changes.outputs.run_renovate_validation == 'true'
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.22
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.23
 
   ci-required:
     name: ci-required
@@ -159,8 +193,10 @@ jobs:
       - detect-changes
       - dependency-review
       - validate-app
+      - install-smoke-app
       - validate-lib
       - validate-test
+      - install-smoke-lib
       - renovate-config-validation
     steps:
       - name: Validate required job results
@@ -172,8 +208,10 @@ jobs:
             ["detect-changes"]="${{ needs.detect-changes.result }}"
             ["dependency-review"]="${{ needs.dependency-review.result }}"
             ["validate-app"]="${{ needs.validate-app.result }}"
+            ["install-smoke-app"]="${{ needs.install-smoke-app.result }}"
             ["validate-lib"]="${{ needs.validate-lib.result }}"
             ["validate-test"]="${{ needs.validate-test.result }}"
+            ["install-smoke-lib"]="${{ needs.install-smoke-lib.result }}"
             ["renovate-config-validation"]="${{ needs.renovate-config-validation.result }}"
           )
 

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.22
+          ref: v0.1.23
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Build pinned validation image
@@ -59,7 +59,7 @@ jobs:
 
       - name: Regenerate render-only snapshots
         # This workflow refreshes render artifacts only. Install-time smoke
-        # remains a separate validation gap until a ct install-class gate exists.
+        # is enforced separately by the shared PR required-check gate.
         run: make snapshot-update BUILD_WORKFLOW=.build-workflow DOCKER_IMAGE=helm-validate:renovate
 
       - name: Commit updated snapshots

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ See `docs/workflow-trigger-matrix.md` for a clear map of:
 build-workflow/
 ├── .github/workflows/
 │   ├── helm-validate.yaml     # Reusable: 5-layer validation pipeline
+│   ├── helm-install-smoke.yaml # Reusable: kind-backed install smoke gate
 │   ├── pr-required-checks-chart.yaml # Reusable: centralized chart PR gate orchestration
 │   ├── release-chart.yaml     # Reusable: publish chart to OCI registry
 │   ├── dependency-review.yaml # Reusable: dependency risk review for PRs
@@ -42,6 +43,8 @@ build-workflow/
 │   ├── validate-metadata.sh       # Layer 3: chart-testing (ct lint)
 │   ├── validate-tests.sh          # Layer 4: helm-unittest + snapshots
 │   ├── validate-policy.sh         # Layer 5: Checkov + kube-linter
+│   ├── run-install-smoke.sh       # Kind-backed helm install smoke
+│   ├── setup-install-smoke-tools.sh # Install pinned cluster smoke binaries
 │   └── update-snapshots.sh        # Shared snapshot regeneration helper
 ├── configs/
 │   ├── yamllint.yaml              # yamllint rules
@@ -67,6 +70,10 @@ A universal, layered Helm chart validation framework that enforces strict qualit
 | 5. Policy Enforcement | Checkov, kube-linter | CIS benchmarks, security best practices |
 
 The pipeline uses **fast-fail**: if any layer fails, subsequent layers are skipped. This ensures developers fix foundational issues (syntax) before investing time in policy checks.
+
+Chart PRs also run a separate install-smoke gate from `pr-required-checks-chart.yaml`.
+That job creates a pinned kind cluster and runs `helm install` with the chart's
+`tests/scenarios/minimal.yaml` values so install-time API errors are caught in CI.
 
 **Key features:**
 - Strict enforcement - all warnings and errors block PRs
@@ -148,6 +155,10 @@ deployment:
         repository: nginx
         tag: "1.27.0"
 ```
+
+`minimal.yaml` must stay installable on a plain kind cluster. Disable optional
+CRD-backed or environment-specific features there unless the install-smoke gate
+also provisions those dependencies.
 
 ```yaml
 # tests/scenarios/full.yaml - enables all features (used by Layer 5 policy scans)

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -1,6 +1,6 @@
 # Build-Workflow Trigger Matrix
 
-Last updated: 2026-04-30
+Last updated: 2026-05-04
 Repository: `orhayoun-eevee/build-workflow`
 
 ## Scope and terms
@@ -22,6 +22,7 @@ Repository: `orhayoun-eevee/build-workflow`
 | `.github/workflows/renovate-config.yaml` | No | Yes (`paths` filtered) | No | Yes | Yes |
 | `.github/workflows/docker-build.yaml` | No | No | Yes (`tags: v*`) | Yes | No |
 | `.github/workflows/helm-validate.yaml` | No (direct) | No (direct) | No (direct) | No | Yes |
+| `.github/workflows/helm-install-smoke.yaml` | No (direct) | No (direct) | No (direct) | No | Yes |
 | `.github/workflows/release-chart.yaml` | No (direct) | No (direct) | No (direct) | No | Yes |
 | `.github/workflows/pr-required-checks-chart.yaml` | No (direct) | No (direct) | No (direct) | No | Yes |
 | `.github/workflows/renovate-snapshot-update.yaml` | No (direct) | No (direct) | No (direct) | No | Yes |
@@ -93,8 +94,9 @@ Why it exists: publish `helm-validate` tool image.
 | Workflow | Internal jobs | Effective run condition |
 |---|---|---|
 | `helm-validate.yaml` | `validate` | Only when called by another workflow/repo. |
+| `helm-install-smoke.yaml` | `install-smoke` | Only when called by another workflow/repo; creates a pinned kind cluster and runs `helm install` with the chart's minimal scenario values. |
 | `release-chart.yaml` | `release` | Only when called; expects tag context in caller for version/tag check. |
-| `pr-required-checks-chart.yaml` | `detect-changes`, `dependency-review`, `validate-*`, `renovate-config-validation`, `ci-required` | Only when chart repos call it; executes chart-specific required-check orchestration. |
+| `pr-required-checks-chart.yaml` | `detect-changes`, `dependency-review`, `validate-*`, `install-smoke-*`, `renovate-config-validation`, `ci-required` | Only when chart repos call it; executes chart-specific required-check orchestration. |
 | `renovate-snapshot-update.yaml` | `update-snapshots` | Only when called in PR context and actor+PR author are `renovate[bot]` from same repo. |
 
 ## Consumer Caller Contract Notes
@@ -105,9 +107,8 @@ Why it exists: publish `helm-validate` tool image.
 - Render-input path filter: `Chart.yaml`, `Chart.lock`, `values.yaml`, `templates/**`, `charts/**`, and `tests/scenarios/**`.
 - Deliberate exclusion: `tests/snapshots/**` is excluded so the bot does not retrigger itself after committing refreshed snapshots.
 - Concurrency contract: the caller wrapper and reusable workflow use distinct group prefixes so the reusable run cannot cancel its caller.
-- Validation scope: snapshot refresh proves render drift only. It does not provide install-time smoke.
-- Explicit remaining gap: no `ct install`-class smoke gate exists as of 2026-04-30. Owner: `build-workflow` maintainer.
-- Manual gate until closed: release or rollout evidence must keep this install-smoke gap explicit and must not claim install confidence from `ct lint` or snapshot refresh alone.
+- Validation scope: snapshot refresh proves render drift only. Install-time smoke is enforced separately by `pr-required-checks-chart.yaml` through `helm-install-smoke.yaml`.
+- Minimal scenario contract: `tests/scenarios/minimal.yaml` must remain installable on a plain kind cluster without extra CRDs or environment-specific controllers.
 
 ## PR vs Merge vs Tag: Practical Summary
 
@@ -115,7 +116,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.22` | `docker-build` only (unless manually dispatching others). |
+| Push tag like `v0.1.23` | `docker-build` only (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.

--- a/scripts/run-install-smoke.sh
+++ b/scripts/run-install-smoke.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Run a kind-backed Helm install smoke using the chart's minimal scenario values.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/common.sh"
+
+: "${CHART_PATH:?CHART_PATH is required}"
+: "${VALUES_FILE:?VALUES_FILE is required}"
+: "${SMOKE_RELEASE_NAME:?SMOKE_RELEASE_NAME is required}"
+: "${SMOKE_NAMESPACE:?SMOKE_NAMESPACE is required}"
+
+if [[ ! -f "${CHART_PATH}/Chart.yaml" ]]; then
+	error "Chart.yaml not found in ${CHART_PATH}"
+	exit 1
+fi
+
+if [[ ! -f "${VALUES_FILE}" ]]; then
+	error "Values file not found: ${VALUES_FILE}"
+	exit 1
+fi
+
+check_command helm || exit 1
+check_command kubectl || exit 1
+
+info "Resolving chart dependencies for ${CHART_PATH}"
+helm dependency build "${CHART_PATH}"
+
+info "Installing ${CHART_PATH} with ${VALUES_FILE}"
+helm install "${SMOKE_RELEASE_NAME}" "${CHART_PATH}" \
+	--namespace "${SMOKE_NAMESPACE}" \
+	--create-namespace \
+	--values "${VALUES_FILE}"
+
+info "Captured installed resources"
+kubectl get all -n "${SMOKE_NAMESPACE}" || true
+kubectl get pvc -n "${SMOKE_NAMESPACE}" || true
+
+success "Install smoke completed successfully"

--- a/scripts/setup-install-smoke-tools.sh
+++ b/scripts/setup-install-smoke-tools.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env bash
+# Install pinned Helm, kubectl, and kind binaries for install-smoke runs.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck disable=SC1091
+source "${SCRIPT_DIR}/lib/common.sh"
+
+: "${HELM_VERSION:?HELM_VERSION is required}"
+: "${KUBECTL_VERSION:?KUBECTL_VERSION is required}"
+: "${KIND_VERSION:?KIND_VERSION is required}"
+
+TOOLS_BIN_DIR="${RUNNER_TEMP:-/tmp}/install-smoke-bin"
+WORK_DIR="$(mktemp -d "${RUNNER_TEMP:-/tmp}/install-smoke-tools-XXXXXX")"
+
+cleanup() {
+	rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+mkdir -p "${TOOLS_BIN_DIR}"
+
+if [[ -n "${GITHUB_PATH:-}" ]]; then
+	echo "${TOOLS_BIN_DIR}" >>"${GITHUB_PATH}"
+fi
+export PATH="${TOOLS_BIN_DIR}:${PATH}"
+
+download_file() {
+	local url="$1"
+	local output="$2"
+	curl -fsSL "${url}" -o "${output}"
+}
+
+install_helm() {
+	local archive="helm-v${HELM_VERSION}-linux-amd64.tar.gz"
+	local checksum_file="${archive}.sha256sum"
+
+	info "Installing Helm v${HELM_VERSION}"
+	download_file "https://get.helm.sh/${archive}" "${WORK_DIR}/${archive}"
+	download_file "https://get.helm.sh/${checksum_file}" "${WORK_DIR}/${checksum_file}"
+	(
+		cd "${WORK_DIR}"
+		grep " ${archive}\$" "${checksum_file}" | sha256sum -c -
+		tar -xzf "${archive}"
+		install -m 0755 "linux-amd64/helm" "${TOOLS_BIN_DIR}/helm"
+	)
+	helm version --short
+}
+
+install_kubectl() {
+	local version="v${KUBECTL_VERSION}"
+
+	info "Installing kubectl ${version}"
+	download_file "https://dl.k8s.io/release/${version}/bin/linux/amd64/kubectl" "${WORK_DIR}/kubectl"
+	download_file "https://dl.k8s.io/release/${version}/bin/linux/amd64/kubectl.sha256" "${WORK_DIR}/kubectl.sha256"
+	(
+		cd "${WORK_DIR}"
+		echo "$(cat kubectl.sha256)  kubectl" | sha256sum --check
+		install -m 0755 kubectl "${TOOLS_BIN_DIR}/kubectl"
+	)
+	kubectl version --client=true
+}
+
+install_kind() {
+	local version="v${KIND_VERSION}"
+
+	info "Installing kind ${version}"
+	download_file "https://kind.sigs.k8s.io/dl/${version}/kind-linux-amd64" "${WORK_DIR}/kind"
+	install -m 0755 "${WORK_DIR}/kind" "${TOOLS_BIN_DIR}/kind"
+	kind version
+}
+
+install_helm
+install_kubectl
+install_kind
+
+success "Install-smoke toolchain is ready"


### PR DESCRIPTION
## Summary
- add a reusable kind-backed install-smoke workflow for chart repos
- wire app and lib chart PR required checks to run install smoke after validation
- update build-workflow docs to replace the old install-smoke gap note

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh