### PR TITLE
ci: validate wrapper-only ref rollouts

### DIFF
--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -109,6 +109,7 @@ Why it exists: publish `helm-validate` tool image.
 - Concurrency contract: the caller wrapper and reusable workflow use distinct group prefixes so the reusable run cannot cancel its caller.
 - Validation scope: snapshot refresh proves render drift only. Install-time smoke is enforced separately by `pr-required-checks-chart.yaml` through `helm-install-smoke.yaml`.
 - Minimal scenario contract: `tests/scenarios/minimal.yaml` must remain installable on a plain kind cluster without extra CRDs or environment-specific controllers.
+- Wrapper rollout contract: changing any consumer wrapper ref (`pr-required-checks`, `on-tag`, `renovate-config`, or `renovate-snapshot-update`) is treated as validation-relevant and re-runs chart CI in PRs.
 
 ## PR vs Merge vs Tag: Practical Summary
 

--- a/scripts/detect-required-checks.sh
+++ b/scripts/detect-required-checks.sh
@@ -85,13 +85,14 @@ fi
 if [[ "${MODE}" == "chart" ]]; then
 	run_validate=false
 	run_renovate_validation=false
+	workflow_wrapper_pattern='^(\.github/workflows/pr-required-checks\.yaml|\.github/workflows/on-tag\.yaml|\.github/workflows/renovate-config\.yaml|\.github/workflows/renovate-snapshot-update\.yaml)$'
 
 	if [[ "${chart_kind}" == "lib" ]]; then
-		if grep -Eq '^(libChart/|test-chart/|tests/|scripts/|Makefile|ct\.yaml|\.checkov\.yaml|\.kube-linter\.yaml)' <<<"${changed_files}"; then
+		if grep -Eq '^(libChart/|test-chart/|tests/|scripts/|Makefile|ct\.yaml|\.checkov\.yaml|\.kube-linter\.yaml)' <<<"${changed_files}" || grep -Eq "${workflow_wrapper_pattern}" <<<"${changed_files}"; then
 			run_validate=true
 		fi
 	else
-		if grep -Eq '^(Chart\.yaml|Chart\.lock|values\.yaml|templates/|tests/|charts/|scripts/|Makefile|ct\.yaml|\.checkov\.yaml|\.kube-linter\.yaml)' <<<"${changed_files}"; then
+		if grep -Eq '^(Chart\.yaml|Chart\.lock|values\.yaml|templates/|tests/|charts/|scripts/|Makefile|ct\.yaml|\.checkov\.yaml|\.kube-linter\.yaml)' <<<"${changed_files}" || grep -Eq "${workflow_wrapper_pattern}" <<<"${changed_files}"; then
 			run_validate=true
 		fi
 	fi

--- a/scripts/test-detect-required-checks.sh
+++ b/scripts/test-detect-required-checks.sh
@@ -130,8 +130,19 @@ EOF
 	out="${tmpdir}/chart-renovate-pr.out"
 	: >"${out}"
 	MODE=chart EVENT_NAME=pull_request BASE_SHA="${head_sha_chart}" HEAD_SHA="${head_sha_renovate}" CHART_KIND=app GITHUB_OUTPUT="${out}" "${DETECT_SCRIPT}"
-	assert_contains "${out}" "run_validate=false"
+	assert_contains "${out}" "run_validate=true"
 	assert_contains "${out}" "run_renovate_validation=true"
+
+	echo "{}" >.github/workflows/pr-required-checks.yaml
+	git add .github/workflows/pr-required-checks.yaml
+	git commit -q -m "required checks wrapper change"
+	head_sha_chart_wrapper="$(git rev-parse HEAD)"
+
+	out="${tmpdir}/chart-wrapper-pr.out"
+	: >"${out}"
+	MODE=chart EVENT_NAME=pull_request BASE_SHA="${head_sha_renovate}" HEAD_SHA="${head_sha_chart_wrapper}" CHART_KIND=app GITHUB_OUTPUT="${out}" "${DETECT_SCRIPT}"
+	assert_contains "${out}" "run_validate=true"
+	assert_contains "${out}" "run_renovate_validation=false"
 
 	mkdir -p libChart
 	echo "name: lib" >libChart/Chart.yaml
@@ -141,7 +152,7 @@ EOF
 
 	out="${tmpdir}/chart-lib-pr.out"
 	: >"${out}"
-	MODE=chart EVENT_NAME=pull_request BASE_SHA="${head_sha_renovate}" HEAD_SHA="${head_sha_lib}" CHART_KIND=lib GITHUB_OUTPUT="${out}" "${DETECT_SCRIPT}"
+	MODE=chart EVENT_NAME=pull_request BASE_SHA="${head_sha_chart_wrapper}" HEAD_SHA="${head_sha_lib}" CHART_KIND=lib GITHUB_OUTPUT="${out}" "${DETECT_SCRIPT}"
 	assert_contains "${out}" "run_validate=true"
 	assert_contains "${out}" "run_renovate_validation=false"
 


### PR DESCRIPTION
## Summary
- treat consumer workflow wrapper ref bumps as validation-relevant chart changes
- update detector regression tests and trigger matrix notes

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh