### PR TITLE
ci: stabilize install smoke namespace handling

### DIFF
--- a/.github/workflows/helm-install-smoke.yaml
+++ b/.github/workflows/helm-install-smoke.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.25
+          ref: v0.1.26
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install install-smoke toolchain

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -109,7 +109,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.25
+          ref: v0.1.26
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Restore Helm caches

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.25
+          ref: v0.1.26
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect changed paths
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.25
+    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.26
 
   validate-app:
     if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.25
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.26
     with:
       chart_path: .
       kubernetes_version: '1.30.0'
@@ -103,7 +103,7 @@ jobs:
       - validate-app
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.25
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.26
     with:
       chart_path: .
       values_file: tests/scenarios/minimal.yaml
@@ -119,7 +119,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.25
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.26
     with:
       chart_path: libChart
       kubernetes_version: '1.30.0'
@@ -141,7 +141,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.25
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.26
     with:
       chart_path: test-chart
       kubernetes_version: '1.30.0'
@@ -165,7 +165,7 @@ jobs:
       - validate-test
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.25
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.26
     with:
       chart_path: test-chart
       values_file: tests/scenarios/minimal.yaml
@@ -180,7 +180,7 @@ jobs:
     if: needs.detect-changes.outputs.run_renovate_validation == 'true'
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.25
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.26
 
   ci-required:
     name: ci-required

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.25
+          ref: v0.1.26
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Build pinned validation image

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -109,6 +109,7 @@ Why it exists: publish `helm-validate` tool image.
 - Concurrency contract: the caller wrapper and reusable workflow use distinct group prefixes so the reusable run cannot cancel its caller.
 - Validation scope: snapshot refresh proves render drift only. Install-time smoke is enforced separately by `pr-required-checks-chart.yaml` through `helm-install-smoke.yaml`.
 - Minimal scenario contract: `tests/scenarios/minimal.yaml` must remain installable on a plain kind cluster without extra CRDs or environment-specific controllers.
+- Namespace contract: install smoke forces `global.namespace` to the temporary smoke namespace so charts with explicit namespace rendering do not depend on repo-default namespaces.
 - Wrapper rollout contract: changing any consumer wrapper ref (`pr-required-checks`, `on-tag`, `renovate-config`, or `renovate-snapshot-update`) is treated as validation-relevant and re-runs chart CI in PRs.
 
 ## PR vs Merge vs Tag: Practical Summary
@@ -117,7 +118,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.25` | `docker-build` only (unless manually dispatching others). |
+| Push tag like `v0.1.26` | `docker-build` only (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.

--- a/scripts/run-install-smoke.sh
+++ b/scripts/run-install-smoke.sh
@@ -31,6 +31,7 @@ info "Installing ${CHART_PATH} with ${VALUES_FILE}"
 helm install "${SMOKE_RELEASE_NAME}" "${CHART_PATH}" \
 	--namespace "${SMOKE_NAMESPACE}" \
 	--create-namespace \
+	--set-string "global.namespace=${SMOKE_NAMESPACE}" \
 	--values "${VALUES_FILE}"
 
 info "Captured installed resources"


### PR DESCRIPTION
## Summary
- force global.namespace to the temporary smoke namespace during install smoke
- align internal build-workflow refs to v0.1.26 in the same release wave
- document the namespace override contract

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh