### PR TITLE
ci: clarify docker-build dispatch tag guard

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -33,7 +33,11 @@ jobs:
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
           if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-            echo "ERROR: Release tag must match vMAJOR.MINOR.PATCH. Got: ${tag}"
+            if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+              echo "ERROR: workflow_dispatch must target an existing semver tag ref (vMAJOR.MINOR.PATCH). Got: ${tag}"
+            else
+              echo "ERROR: Release tag must match vMAJOR.MINOR.PATCH. Got: ${tag}"
+            fi
             exit 1
           fi
 

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -87,7 +87,7 @@ Why it exists: publish `helm-validate` tool image.
 
 | Job | Runs when | Why |
 |---|---|---|
-| `build-and-push` | Tag push `v*` or manual dispatch | Release image only on explicit release signal (tag) or intentional manual run. |
+| `build-and-push` | Tag push `v*` or manual dispatch against an existing semver tag ref | Release image only on explicit release signal (tag) or intentional manual run on a real release ref. |
 
 ### 8) Reusable-only workflows
 


### PR DESCRIPTION
## Summary
- keep docker-build tag-only for real releases
- make manual dispatch failures explicit when the selected ref is not a semver tag
- document the manual dispatch tag-ref requirement

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh