### PR TITLE
ci: narrow renovate snapshot token scope

### DIFF
--- a/.github/workflows/helm-install-smoke.yaml
+++ b/.github/workflows/helm-install-smoke.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.28
+          ref: v0.1.29
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install install-smoke toolchain

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.28
+      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.29
     outputs:
       unit_test_files: ${{ steps.quality-metrics.outputs.unit_test_files }}
       unit_test_assertions: ${{ steps.quality-metrics.outputs.unit_test_assertions }}
@@ -109,7 +109,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.28
+          ref: v0.1.29
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Restore Helm caches

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.28
+          ref: v0.1.29
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect changed paths
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.28
+    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.29
 
   validate-app:
     if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.28
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.29
     with:
       chart_path: .
       kubernetes_version: '1.30.0'
@@ -103,7 +103,7 @@ jobs:
       - validate-app
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.28
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.29
     with:
       chart_path: .
       values_file: tests/scenarios/minimal.yaml
@@ -119,7 +119,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.28
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.29
     with:
       chart_path: libChart
       kubernetes_version: '1.30.0'
@@ -141,7 +141,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.28
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.29
     with:
       chart_path: test-chart
       kubernetes_version: '1.30.0'
@@ -165,7 +165,7 @@ jobs:
       - validate-test
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.28
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.29
     with:
       chart_path: test-chart
       values_file: tests/scenarios/minimal.yaml
@@ -180,7 +180,7 @@ jobs:
     if: needs.detect-changes.outputs.run_renovate_validation == 'true'
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.28
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.29
 
   ci-required:
     name: ci-required

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   BUILD_WORKFLOW_REPOSITORY: orhayoun-eevee/build-workflow
-  BUILD_WORKFLOW_REF: v0.1.28
+  BUILD_WORKFLOW_REF: v0.1.29
 
 concurrency:
   group: reusable-renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
@@ -42,9 +42,7 @@ jobs:
           app-id: ${{ secrets.gh_app_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ github.repository_owner }}
-          repositories: |
-            ${{ github.event.pull_request.head.repo.name }}
-            build-workflow
+          repositories: ${{ github.event.pull_request.head.repo.name }}
           permission-contents: write
 
       - name: Checkout PR branch
@@ -62,7 +60,6 @@ jobs:
           path: .build-workflow
           ref: ${{ env.BUILD_WORKFLOW_REF }}
           persist-credentials: false
-          token: ${{ steps.app-token.outputs.token }}
 
       - name: Build pinned validation image
         run: make docker-build BUILD_WORKFLOW=.build-workflow DOCKER_IMAGE=helm-validate:renovate

--- a/README.md
+++ b/README.md
@@ -402,11 +402,12 @@ push only `tests/snapshots/**` changes back to the existing PR branch.
 - distinct caller and reusable concurrency group prefixes
 
 **How it works:**
-1. Mints a GitHub App installation token scoped to the current app-chart repo
-   plus `build-workflow`.
+1. Mints a GitHub App installation token scoped only to the current app-chart
+   repo for same-branch write-back.
 2. Checks out the Renovate PR branch with persisted default credentials
    disabled.
-3. Checks out `build-workflow` at the ref pinned by the reusable workflow.
+3. Checks out the public `build-workflow` repo at the ref pinned by the
+   reusable workflow.
 4. Builds the pinned validation image locally as `helm-validate:renovate`.
 5. Runs `make snapshot-update` against the checked-out build-workflow copy.
 6. Fails if any path outside `snapshots_dir` changed.

--- a/docs/incidents/2026-05-11-renovate-snapshot-writeback-403.md
+++ b/docs/incidents/2026-05-11-renovate-snapshot-writeback-403.md
@@ -23,6 +23,30 @@ These run IDs came from the rollout design and ADR evidence set available on
 2026-05-05. The exact root cause was still unconfirmed when this note was
 created.
 
+## 2026-05-07 Canary Follow-Up
+
+Controlled canary PR: `jellyfin-helm#15` (`renovate/helm-dependencies`)
+
+| Repo | PR | GitHub run ID | Observed symptom |
+|------|----|---------------|------------------|
+| `jellyfin-helm` | `#15` | `25493423181` | Token mint failed before checkout with HTTP `422`: the GitHub App installation did not grant the requested multi-repo token scope (`jellyfin-helm, build-workflow`) |
+
+Paired required-check evidence on the same PR head SHA:
+
+| Repo | PR | GitHub run ID | Observed result |
+|------|----|---------------|-----------------|
+| `jellyfin-helm` | `#15` | `25493423409` | `ci-required` passed on pre-write head SHA `594a69b249618f98e10193b8cb4178aee8cd7c31` |
+
+Key log lines from run `25493423181`:
+
+- `Failed to create token for "jellyfin-helm,build-workflow" (attempt 1): The permissions requested are not granted to this installation.`
+- API status: `422`
+- Workflow ref under test: `orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@refs/tags/v0.1.28`
+
+This follow-up narrows the producer-side defect: at least one current failure
+mode occurs before snapshot regeneration or push-back, and it is caused by the
+requested GitHub App repository scope rather than by branch write-back itself.
+
 ## What This Confirms
 
 - Same-branch GitHub Actions write-back was exercised in multiple app-chart
@@ -35,6 +59,9 @@ created.
 
 - Whether the failure was caused by branch protection, repo rulesets, app
   installation scope, token permissions, or another GitHub-side condition.
+- Whether the newer canary-side `422` token-mint failure is the only remaining
+  defect after producer hardening, or whether any downstream push-back `403`
+  still remains once token scope is corrected.
 - Whether later workflow hardening fully removes the symptom across all repos.
 - Whether a given failed run had snapshot drift, no-op output, or another
   contributing repository state without its preserved workflow summary.

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -110,7 +110,7 @@ Why it exists: publish `helm-validate` tool image.
 - Render-input path filter: `Chart.yaml`, `Chart.lock`, `values.yaml`, `templates/**`, `charts/**`, and `tests/scenarios/**`.
 - Deliberate exclusion: `tests/snapshots/**` is excluded so the bot does not retrigger itself after committing refreshed snapshots.
 - Concurrency contract: the caller wrapper and reusable workflow use distinct group prefixes so the reusable run cannot cancel its caller.
-- Secrets contract: the caller passes `GHCR_AUTO_APP_ID` and `GHCR_AUTO_PKEY`; the reusable interface remains `workflow_call` with `snapshots_dir`.
+- Secrets contract: the caller passes `GHCR_AUTO_APP_ID` and `GHCR_AUTO_PKEY`; the reusable interface remains `workflow_call` with `snapshots_dir`. The GitHub App token is scoped only to the caller repo for same-branch write-back; the public `build-workflow` checkout does not request app access.
 - Mutation contract: same-branch GitHub App write-back only. No `GITHUB_TOKEN`, PAT, manual branch update, or second PR fallback is part of the active contract.
 - Evidence contract: every run summarizes repo, PR number, PR head ref, pre-write PR head SHA, `build-workflow` ref, result, changed snapshot file count, and pushed commit SHA. Push failures also capture current ref, target ref, `git status`, snapshot diff scope, and sanitized push stderr.
 - Validation scope: snapshot refresh proves render drift only. Install-time smoke is enforced separately by `pr-required-checks-chart.yaml` through `helm-install-smoke.yaml`.
@@ -125,7 +125,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.28` | `docker-build` only (unless manually dispatching others). |
+| Push tag like `v0.1.29` | `docker-build` only (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.


### PR DESCRIPTION
## Summary
- scope the Renovate snapshot write-back app token to the caller repo only
- stop requesting app access to build-workflow for public helper checkout
- record the PR #15 canary 422 evidence and roll self refs to v0.1.29

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh