### PR TITLE
ci: ignore helper checkout in snapshot updater

### DIFF
--- a/.github/workflows/helm-install-smoke.yaml
+++ b/.github/workflows/helm-install-smoke.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.29
+          ref: v0.1.30
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install install-smoke toolchain

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.29
+      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.30
     outputs:
       unit_test_files: ${{ steps.quality-metrics.outputs.unit_test_files }}
       unit_test_assertions: ${{ steps.quality-metrics.outputs.unit_test_assertions }}
@@ -109,7 +109,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.29
+          ref: v0.1.30
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Restore Helm caches

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.29
+          ref: v0.1.30
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect changed paths
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.29
+    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.30
 
   validate-app:
     if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.29
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.30
     with:
       chart_path: .
       kubernetes_version: '1.30.0'
@@ -103,7 +103,7 @@ jobs:
       - validate-app
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.29
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.30
     with:
       chart_path: .
       values_file: tests/scenarios/minimal.yaml
@@ -119,7 +119,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.29
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.30
     with:
       chart_path: libChart
       kubernetes_version: '1.30.0'
@@ -141,7 +141,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.29
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.30
     with:
       chart_path: test-chart
       kubernetes_version: '1.30.0'
@@ -165,7 +165,7 @@ jobs:
       - validate-test
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.29
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.30
     with:
       chart_path: test-chart
       values_file: tests/scenarios/minimal.yaml
@@ -180,7 +180,7 @@ jobs:
     if: needs.detect-changes.outputs.run_renovate_validation == 'true'
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.29
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.30
 
   ci-required:
     name: ci-required

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   BUILD_WORKFLOW_REPOSITORY: orhayoun-eevee/build-workflow
-  BUILD_WORKFLOW_REF: v0.1.29
+  BUILD_WORKFLOW_REF: v0.1.30
 
 concurrency:
   group: reusable-renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
@@ -97,12 +97,26 @@ jobs:
             } >> "${GITHUB_OUTPUT}"
           }
 
+          is_expected_workspace_path() {
+            local path="$1"
+            case "${path}" in
+              .build-workflow|.build-workflow/*)
+                return 0
+                ;;
+              *)
+                return 1
+                ;;
+            esac
+          }
+
           current_ref="$(git rev-parse --abbrev-ref HEAD)"
+          raw_git_status_file="$(mktemp)"
           git_status_file="$(mktemp)"
           snapshot_diff_stat_file="$(mktemp)"
           unexpected_paths_file="$(mktemp)"
 
-          git status --short --untracked-files=all > "${git_status_file}"
+          git status --short --untracked-files=all > "${raw_git_status_file}"
+          : > "${git_status_file}"
           git diff --stat -- "${SNAPSHOTS_DIR}" > "${snapshot_diff_stat_file}" || true
           : > "${unexpected_paths_file}"
 
@@ -111,6 +125,11 @@ jobs:
             [[ -z "${line}" ]] && continue
 
             path="${line:3}"
+            if is_expected_workspace_path "${path}"; then
+              continue
+            fi
+
+            printf '%s\n' "${line}" >> "${git_status_file}"
             case "${path}" in
               "${SNAPSHOTS_DIR}"|"${SNAPSHOTS_DIR}/"*)
                 snapshot_change_count=$((snapshot_change_count + 1))
@@ -119,7 +138,7 @@ jobs:
                 printf '%s\n' "${path}" >> "${unexpected_paths_file}"
                 ;;
             esac
-          done < <(git status --porcelain=v1 --untracked-files=all)
+          done < "${raw_git_status_file}"
 
           {
             echo "current_ref=${current_ref}"

--- a/docs/incidents/2026-05-11-renovate-snapshot-writeback-403.md
+++ b/docs/incidents/2026-05-11-renovate-snapshot-writeback-403.md
@@ -47,6 +47,108 @@ This follow-up narrows the producer-side defect: at least one current failure
 mode occurs before snapshot regeneration or push-back, and it is caused by the
 requested GitHub App repository scope rather than by branch write-back itself.
 
+## 2026-05-07 Fixed-Producer Canary
+
+Controlled canary PR: `jellyfin-helm#22` (`renovate/helm-dependencies`)
+
+| Repo | PR | GitHub run ID | Observed symptom |
+|------|----|---------------|------------------|
+| `jellyfin-helm` | `#22` | `25498395519` | Token mint still failed before checkout with HTTP `422` even after narrowing the requested repo scope to `jellyfin-helm` only |
+
+Paired required-check evidence on the same PR head SHA:
+
+| Repo | PR | GitHub run ID | Observed result |
+|------|----|---------------|-----------------|
+| `jellyfin-helm` | `#22` | `25498396039` | `ci-required` passed on pre-write head SHA `58c467ebcad9f552645eadc9d245c16d4744f17a` |
+
+Key log lines from run `25498395519`:
+
+- `Uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@refs/tags/v0.1.29`
+- `repositories: jellyfin-helm`
+- `Failed to create token for "jellyfin-helm" (attempt 1): The permissions requested are not granted to this installation.`
+- API status: `422`
+
+This canary disproves the narrower hypothesis that multi-repo token scope was
+the only defect. After `build-workflow@v0.1.29`, the active remaining blocker
+is external to the repo code: the GitHub App installation used by
+`GHCR_AUTO_APP_ID` does not currently grant the requested `contents: write`
+token scope for `jellyfin-helm`.
+
+## 2026-05-08 Post-Permission Canary
+
+Controlled canary PR: `jellyfin-helm#24` (`renovate/helm-dependencies`)
+
+| Repo | PR | GitHub run ID | Observed symptom |
+|------|----|---------------|------------------|
+| `jellyfin-helm` | `#24` | `25545943987` | Token mint and repo checkout succeeded, but snapshot write-back failed because the reusable workflow treated `.build-workflow/` as an unexpected non-snapshot diff |
+
+Paired required-check evidence on the same PR head SHA:
+
+| Repo | PR | GitHub run ID | Observed result |
+|------|----|---------------|-----------------|
+| `jellyfin-helm` | `#24` | `25545944131` | `ci-required` ran on head SHA `8884293c9f11dab45104f5966d5bedbfc1f55350`; the remaining failure moved out of token minting and into producer-side diff filtering |
+
+Key log lines from run `25545943987`:
+
+- `Created token for app installation`
+- `Checked out build-workflow to .build-workflow`
+- `Unexpected non-snapshot changes detected after snapshot refresh`
+- `Git status:`
+- `?? .build-workflow/`
+- `UNEXPECTED_PATHS: .build-workflow/`
+- `RESULT: unexpected-diff`
+- `SNAPSHOT_CHANGE_COUNT: 0`
+
+This canary confirms the external GitHub App permission fix worked. The active
+remaining blocker moved back into repo code: `build-workflow` must ignore its
+own helper checkout path when classifying unexpected mutations in the reusable
+snapshot updater.
+
+## External Configuration Findings
+
+Collected on 2026-05-07 with GitHub API and workflow evidence:
+
+- Organization Actions secrets exist at org scope, not repo scope:
+  - `GHCR_AUTO_APP_ID`
+  - `GHCR_AUTO_PKEY`
+  - visibility: `all`
+- The GitHub App installation tied to the failing workflow includes the in-scope
+  repositories. User-accessible installation repository listing for
+  installation `104870162` returned:
+  - `helm-common-lib`
+  - `radarr-helm`
+  - `build-workflow`
+  - `sonarr-helm`
+  - `sabnzbd-helm`
+  - `transmission-helm`
+  - `home-assistant-helm`
+  - `ha-config`
+  - `seerr-helm`
+  - `jellyfin-helm`
+- `jellyfin-helm` repository rulesets are currently empty.
+
+Interpretation:
+
+- Missing repository selection is not the current blocker.
+- Missing org-level secrets are not the current blocker.
+- Repository rulesets are not the current blocker in `jellyfin-helm`.
+- The remaining likely blocker is GitHub App permission grant state:
+  the installation can see the repo, but GitHub refuses to mint an installation
+  token when `contents: write` is requested.
+
+## Most Likely Remediation
+
+Review the installed GitHub App under the owning account or organization and
+confirm both of these conditions:
+
+1. Under `Permissions`, the app has repository `Contents` permission set to
+   `Read and write`.
+2. If that permission was added or upgraded after installation, the
+   installation has approved the updated permissions.
+
+If the app is intentionally read-only, the active same-branch write-back
+contract in ADR-0002 cannot succeed and must be superseded instead of widened.
+
 ## What This Confirms
 
 - Same-branch GitHub Actions write-back was exercised in multiple app-chart
@@ -62,6 +164,9 @@ requested GitHub App repository scope rather than by branch write-back itself.
 - Whether the newer canary-side `422` token-mint failure is the only remaining
   defect after producer hardening, or whether any downstream push-back `403`
   still remains once token scope is corrected.
+- Whether the installed GitHub App should be granted `contents: write` on the
+  affected app-chart repos, or whether the workspace should supersede
+  ADR-0002's active mutation contract.
 - Whether later workflow hardening fully removes the symptom across all repos.
 - Whether a given failed run had snapshot drift, no-op output, or another
   contributing repository state without its preserved workflow summary.

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -125,7 +125,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.29` | `docker-build` only (unless manually dispatching others). |
+| Push tag like `v0.1.30` | `docker-build` only (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.


### PR DESCRIPTION
## Summary\n- ignore the reusable workflow helper checkout when classifying unexpected snapshot write-back diffs\n- align build-workflow internal refs to v0.1.30 for the next immutable release\n- record the renewed Jellyfin canary evidence in the incident log\n\n## Validation\n- make -C build-workflow lint\n- build-workflow/scripts/test-detect-required-checks.sh