### PR TITLE
ci: allow trusted bot refreshes for renovate branches

### DIFF
--- a/.github/workflows/helm-install-smoke.yaml
+++ b/.github/workflows/helm-install-smoke.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.30
+          ref: v0.1.31
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install install-smoke toolchain

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.30
+      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.31
     outputs:
       unit_test_files: ${{ steps.quality-metrics.outputs.unit_test_files }}
       unit_test_assertions: ${{ steps.quality-metrics.outputs.unit_test_assertions }}
@@ -109,7 +109,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.30
+          ref: v0.1.31
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Restore Helm caches

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.30
+          ref: v0.1.31
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect changed paths
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.30
+    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.31
 
   validate-app:
     if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.30
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.31
     with:
       chart_path: .
       kubernetes_version: '1.30.0'
@@ -103,7 +103,7 @@ jobs:
       - validate-app
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.30
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.31
     with:
       chart_path: .
       values_file: tests/scenarios/minimal.yaml
@@ -119,7 +119,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.30
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.31
     with:
       chart_path: libChart
       kubernetes_version: '1.30.0'
@@ -141,7 +141,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.30
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.31
     with:
       chart_path: test-chart
       kubernetes_version: '1.30.0'
@@ -165,7 +165,7 @@ jobs:
       - validate-test
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.30
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.31
     with:
       chart_path: test-chart
       values_file: tests/scenarios/minimal.yaml
@@ -180,7 +180,7 @@ jobs:
     if: needs.detect-changes.outputs.run_renovate_validation == 'true'
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.30
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.31
 
   ci-required:
     name: ci-required

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   BUILD_WORKFLOW_REPOSITORY: orhayoun-eevee/build-workflow
-  BUILD_WORKFLOW_REF: v0.1.30
+  BUILD_WORKFLOW_REF: v0.1.31
 
 concurrency:
   group: reusable-renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}
@@ -30,7 +30,7 @@ concurrency:
 
 jobs:
   update-snapshots:
-    if: github.event_name == 'pull_request' && github.actor == 'renovate[bot]' && github.event.pull_request.user.login == 'renovate[bot]' && github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && startsWith(github.event.pull_request.head.ref, 'renovate/') && (github.actor == 'renovate[bot]' || github.actor == 'ghcr-automation[bot]') && (github.event.pull_request.user.login == 'renovate[bot]' || github.event.pull_request.user.login == 'app/renovate')
     runs-on: ubuntu-latest
     timeout-minutes: 20
 

--- a/docs/incidents/2026-05-11-renovate-snapshot-writeback-403.md
+++ b/docs/incidents/2026-05-11-renovate-snapshot-writeback-403.md
@@ -104,6 +104,31 @@ remaining blocker moved back into repo code: `build-workflow` must ignore its
 own helper checkout path when classifying unexpected mutations in the reusable
 snapshot updater.
 
+## 2026-05-08 Home Assistant Rebase Follow-Up
+
+Refreshed Renovate PR: `home-assistant-helm#2` (`renovate/container-images`)
+
+| Repo | PR | GitHub run ID | Observed symptom |
+|------|----|---------------|------------------|
+| `home-assistant-helm` | `#2` | `25548754098` | The refreshed pull request used trusted repo-local bot actor `ghcr-automation[bot]`, but the reusable workflow still skipped because its guard only allowed `renovate[bot]` |
+
+Supporting evidence:
+
+- PR head branch: `renovate/container-images`
+- PR remained same-repo (`home-assistant-helm`)
+- workflow run metadata:
+  - `event: pull_request`
+  - `actor: ghcr-automation[bot]`
+  - `triggering_actor: ghcr-automation[bot]`
+  - `head_sha: c8467fe8c8616c6c8deb735a0d635b8f037b3b2c`
+- paired required-check run `25548754140` passed on the same refreshed head SHA
+
+This follow-up narrows the next producer-side defect: the active job guard is
+too strict for the trusted bot identities now used during same-repo Renovate
+branch refreshes. The next hardening step must allow the known trusted bot
+actor set for same-repo `renovate/*` pull requests without reopening the manual
+actor path that was intentionally blocked earlier.
+
 ## External Configuration Findings
 
 Collected on 2026-05-07 with GitHub API and workflow evidence:

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -125,7 +125,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.30` | `docker-build` only (unless manually dispatching others). |
+| Push tag like `v0.1.31` | `docker-build` only (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.


### PR DESCRIPTION
## Summary\n- allow trusted same-repo bot refreshes for renovate/* pull requests\n- keep the manual actor path blocked while accepting ghcr-automation[bot] alongside renovate[bot]\n- align build-workflow self refs to v0.1.31 and record the Home Assistant evidence\n\n## Validation\n- make -C build-workflow lint\n- build-workflow/scripts/test-detect-required-checks.sh