### PR TITLE
ci: gate toolchain image publish

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -22,6 +22,7 @@ jobs:
   build-and-push:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    environment: toolchain-release
 
     steps:
       - name: Checkout repository
@@ -32,6 +33,14 @@ jobs:
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
+          if [[ "${GITHUB_REF_TYPE}" != "tag" || "${GITHUB_REF}" != refs/tags/* ]]; then
+            if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+              echo "ERROR: workflow_dispatch must target an existing tag ref. Got ${GITHUB_REF_TYPE}:${GITHUB_REF}"
+            else
+              echo "ERROR: Release workflow must run from a tag ref. Got ${GITHUB_REF_TYPE}:${GITHUB_REF}"
+            fi
+            exit 1
+          fi
           if [[ ! "${tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
             if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
               echo "ERROR: workflow_dispatch must target an existing semver tag ref (vMAJOR.MINOR.PATCH). Got: ${tag}"

--- a/README.md
+++ b/README.md
@@ -466,7 +466,10 @@ wrapper.
 
 **Purpose:** Builds and pushes the `helm-validate` Docker image to GHCR.
 
-**Triggers:** Push to tags matching `v*`, or manual `workflow_dispatch`.
+**Triggers:** Push to tags matching `v*`, or manual `workflow_dispatch` against an existing semver `v*` tag ref.
+
+**Environment gate:** The `build-and-push` job requires the `toolchain-release`
+environment before publishing to GHCR.
 
 Published tags: `X.Y.Z`, `X.Y`, `X`.
 
@@ -626,9 +629,9 @@ docker build -t helm-validate:local -f docker/Dockerfile docker/
 1. Update the version in `docker/Dockerfile`
 2. Rebuild and test: `docker build -t helm-validate:local -f docker/Dockerfile docker/`
 3. Publish flow:
-   - automatic publish on `main` when docker build inputs change
-   - automatic versioned publish on `v*` tag push
-   - optional manual publish via `workflow_dispatch`
+   - automatic versioned publish on `v*` tag push only
+   - optional manual publish via `workflow_dispatch` on an existing semver `v*` tag ref
+   - both publish paths require the `toolchain-release` environment before pushing to GHCR
 
 ---
 

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -23,7 +23,7 @@ The GitHub wiki is disabled for this repository. Use this file and
 | `.github/workflows/dependency-review.yaml` | No (direct) | No | No | No | Yes |
 | `.github/workflows/detect-required-checks-tests.yaml` | Yes (`paths` filtered) | Yes (`paths` filtered) | No | No | No |
 | `.github/workflows/renovate-config.yaml` | No | Yes (`paths` filtered) | No | Yes | Yes |
-| `.github/workflows/docker-build.yaml` | No | No | Yes (`tags: v*`) | Yes | No |
+| `.github/workflows/docker-build.yaml` | No | No | Yes (`tags: v*`) | Yes (`workflow_dispatch`, existing semver `v*` ref only) | No |
 | `.github/workflows/helm-validate.yaml` | No (direct) | No (direct) | No (direct) | No | Yes |
 | `.github/workflows/helm-install-smoke.yaml` | No (direct) | No (direct) | No (direct) | No | Yes |
 | `.github/workflows/release-chart.yaml` | No (direct) | No (direct) | No (direct) | No | Yes |
@@ -90,7 +90,7 @@ Why it exists: publish `helm-validate` tool image.
 
 | Job | Runs when | Why |
 |---|---|---|
-| `build-and-push` | Tag push `v*` or manual dispatch against an existing semver tag ref | Release image only on explicit release signal (tag) or intentional manual run on a real release ref. |
+| `build-and-push` | Tag push `v*` or manual dispatch against an existing semver `v*` tag ref | Release image only on governed release refs, and require the `toolchain-release` environment before pushing to GHCR. |
 
 ### 8) Reusable-only workflows
 
@@ -125,7 +125,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.32` | `docker-build` only (unless manually dispatching others). |
+| Push tag like `v0.1.32` | `docker-build` only, gated by `toolchain-release` (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.


### PR DESCRIPTION
## Summary
- gate the helm-validate image publish job with the toolchain-release environment
- reject non-tag refs before registry login/push, including manual dispatch on semver-shaped branches
- update build-workflow docs for the governed tag/manual publish flow

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh
- scripts/check-local-skill-policy.sh

## Scope
- repo-internal build-workflow hardening
- no chart consumer repo changes
- no ha-config changes