### PR TITLE
ci: prepare build workflow v0.1.33

### DIFF
--- a/.github/workflows/helm-install-smoke.yaml
+++ b/.github/workflows/helm-install-smoke.yaml
@@ -69,7 +69,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.32
+          ref: v0.1.33
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install install-smoke toolchain

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.32
+      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.33
     outputs:
       unit_test_files: ${{ steps.quality-metrics.outputs.unit_test_files }}
       unit_test_assertions: ${{ steps.quality-metrics.outputs.unit_test_assertions }}
@@ -109,7 +109,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.32
+          ref: v0.1.33
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Restore Helm caches

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -51,7 +51,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.32
+          ref: v0.1.33
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect changed paths
@@ -71,7 +71,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.32
+    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.33
 
   validate-app:
     if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
@@ -79,7 +79,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.32
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.33
     with:
       chart_path: .
       kubernetes_version: '1.30.0'
@@ -103,7 +103,7 @@ jobs:
       - validate-app
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.32
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.33
     with:
       chart_path: .
       values_file: tests/scenarios/minimal.yaml
@@ -119,7 +119,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.32
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.33
     with:
       chart_path: libChart
       kubernetes_version: '1.30.0'
@@ -141,7 +141,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.32
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.33
     with:
       chart_path: test-chart
       kubernetes_version: '1.30.0'
@@ -165,7 +165,7 @@ jobs:
       - validate-test
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.32
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.33
     with:
       chart_path: test-chart
       values_file: tests/scenarios/minimal.yaml
@@ -180,7 +180,7 @@ jobs:
     if: needs.detect-changes.outputs.run_renovate_validation == 'true'
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.32
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.33
 
   ci-required:
     name: ci-required

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   BUILD_WORKFLOW_REPOSITORY: orhayoun-eevee/build-workflow
-  BUILD_WORKFLOW_REF: v0.1.32
+  BUILD_WORKFLOW_REF: v0.1.33
 
 concurrency:
   group: reusable-renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -125,7 +125,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.32` | `docker-build` only, gated by `toolchain-release` (unless manually dispatching others). |
+| Push tag like `v0.1.33` | `docker-build` only, gated by `toolchain-release` (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.


### PR DESCRIPTION
## Summary
- bump build-workflow internal self refs from v0.1.32 to v0.1.33
- keep reusable workflow/runtime image refs version-matched for the next release tag
- update the docker-build tag example in the trigger matrix

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh
- scripts/check-local-skill-policy.sh
- quality-fixer gate: approved

## Scope
- repo-internal build-workflow release prep
- no chart consumer repo changes
- no ha-config changes

## Follow-up after merge
- create annotated tag v0.1.33 from merged main
- verify the protected docker-build publish run uses toolchain-release