### PR TITLE
ci: harden github app token contract

### DIFF
--- a/.github/workflows/helm-install-smoke.yaml
+++ b/.github/workflows/helm-install-smoke.yaml
@@ -20,8 +20,8 @@ on:
         required: true
         type: string
     secrets:
-      gh_app_id:
-        description: 'GitHub App ID for minting installation token'
+      gh_app_client_id:
+        description: 'GitHub App client ID for minting installation token'
         required: true
       gh_app_private_key:
         description: 'GitHub App private key for minting installation token'
@@ -60,9 +60,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.gh_app_id }}
+          client-id: ${{ secrets.gh_app_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ github.repository_owner }}
+          repositories: build-workflow
+          permission-contents: read
 
       - name: Checkout build-workflow helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -62,8 +62,8 @@ on:
         type: string
         default: ''
     secrets:
-      gh_app_id:
-        description: 'GitHub App ID for minting installation token'
+      gh_app_client_id:
+        description: 'GitHub App client ID for minting installation token'
         required: true
       gh_app_private_key:
         description: 'GitHub App private key for minting installation token'
@@ -100,9 +100,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.gh_app_id }}
+          client-id: ${{ secrets.gh_app_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ github.repository_owner }}
+          repositories: build-workflow
+          permission-contents: read
 
       - name: Checkout build-workflow (validation framework)
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -8,8 +8,8 @@ on:
         required: true
         type: string
     secrets:
-      gh_app_id:
-        description: 'GitHub App ID for minting installation token'
+      gh_app_client_id:
+        description: 'GitHub App client ID for minting installation token'
         required: true
       gh_app_private_key:
         description: 'GitHub App private key for minting installation token'
@@ -42,9 +42,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.gh_app_id }}
+          client-id: ${{ secrets.gh_app_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ github.repository_owner }}
+          repositories: build-workflow
+          permission-contents: read
 
       - name: Checkout build-workflow helpers
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -93,7 +95,7 @@ jobs:
       target_branch: main
       run_version_check: true
     secrets:
-      gh_app_id: ${{ secrets.gh_app_id }}
+      gh_app_client_id: ${{ secrets.gh_app_client_id }}
       gh_app_private_key: ${{ secrets.gh_app_private_key }}
 
   install-smoke-app:
@@ -110,7 +112,7 @@ jobs:
       kubernetes_version: '1.30.0'
       kind_node_image: 'kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e'
     secrets:
-      gh_app_id: ${{ secrets.gh_app_id }}
+      gh_app_client_id: ${{ secrets.gh_app_client_id }}
       gh_app_private_key: ${{ secrets.gh_app_private_key }}
 
   validate-lib:
@@ -130,7 +132,7 @@ jobs:
       run_policy: false
       run_version_check: true
     secrets:
-      gh_app_id: ${{ secrets.gh_app_id }}
+      gh_app_client_id: ${{ secrets.gh_app_client_id }}
       gh_app_private_key: ${{ secrets.gh_app_private_key }}
 
   validate-test:
@@ -155,7 +157,7 @@ jobs:
       target_branch: main
       run_version_check: false
     secrets:
-      gh_app_id: ${{ secrets.gh_app_id }}
+      gh_app_client_id: ${{ secrets.gh_app_client_id }}
       gh_app_private_key: ${{ secrets.gh_app_private_key }}
 
   install-smoke-lib:
@@ -172,7 +174,7 @@ jobs:
       kubernetes_version: '1.30.0'
       kind_node_image: 'kindest/node:v1.30.0@sha256:047357ac0cfea04663786a612ba1eaba9702bef25227a794b52890dd8bcd692e'
     secrets:
-      gh_app_id: ${{ secrets.gh_app_id }}
+      gh_app_client_id: ${{ secrets.gh_app_client_id }}
       gh_app_private_key: ${{ secrets.gh_app_private_key }}
 
   renovate-config-validation:

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -9,8 +9,8 @@ on:
         type: string
         default: 'tests/snapshots'
     secrets:
-      gh_app_id:
-        description: 'GitHub App ID for minting installation token'
+      gh_app_client_id:
+        description: 'GitHub App client ID for minting installation token'
         required: true
       gh_app_private_key:
         description: 'GitHub App private key for minting installation token'
@@ -39,7 +39,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.gh_app_id }}
+          client-id: ${{ secrets.gh_app_client_id }}
           private-key: ${{ secrets.gh_app_private_key }}
           owner: ${{ github.repository_owner }}
           repositories: ${{ github.event.pull_request.head.repo.name }}

--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ jobs:
       chart_path: .
       kubernetes_version: "1.30.0"
     secrets:
-      gh_app_id: ${{ secrets.GHCR_AUTO_APP_ID }}
+      gh_app_client_id: ${{ secrets.GHCR_AUTO_CLIENT_ID }}
       gh_app_private_key: ${{ secrets.GHCR_AUTO_PKEY }}
 ```
 
@@ -390,7 +390,7 @@ push only `tests/snapshots/**` changes back to the existing PR branch.
 | `snapshots_dir` | string | No | `tests/snapshots` | Snapshot directory staged and committed by the reusable workflow |
 
 **Required secrets:**
-- `gh_app_id`
+- `gh_app_client_id`
 - `gh_app_private_key`
 
 **Caller wrapper contract:**

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -1,6 +1,6 @@
 # Build-Workflow Trigger Matrix
 
-Last updated: 2026-05-05
+Last updated: 2026-05-27
 Repository: `orhayoun-eevee/build-workflow`
 
 The GitHub wiki is disabled for this repository. Use this file and
@@ -110,7 +110,7 @@ Why it exists: publish `helm-validate` tool image.
 - Render-input path filter: `Chart.yaml`, `Chart.lock`, `values.yaml`, `templates/**`, `charts/**`, and `tests/scenarios/**`.
 - Deliberate exclusion: `tests/snapshots/**` is excluded so the bot does not retrigger itself after committing refreshed snapshots.
 - Concurrency contract: the caller wrapper and reusable workflow use distinct group prefixes so the reusable run cannot cancel its caller.
-- Secrets contract: the caller passes `GHCR_AUTO_APP_ID` and `GHCR_AUTO_PKEY`; the reusable interface remains `workflow_call` with `snapshots_dir`. The GitHub App token is scoped only to the caller repo for same-branch write-back; the public `build-workflow` checkout does not request app access.
+- Secrets contract: the caller passes `GHCR_AUTO_CLIENT_ID` and `GHCR_AUTO_PKEY`; the reusable interface remains `workflow_call` with `snapshots_dir`. The GitHub App token is scoped only to the caller repo for same-branch write-back; the public `build-workflow` checkout does not request app access.
 - Mutation contract: same-branch GitHub App write-back only. No `GITHUB_TOKEN`, PAT, manual branch update, or second PR fallback is part of the active contract.
 - Evidence contract: every run summarizes repo, PR number, PR head ref, pre-write PR head SHA, `build-workflow` ref, result, changed snapshot file count, and pushed commit SHA. Push failures also capture current ref, target ref, `git status`, snapshot diff scope, and sanitized push stderr.
 - Validation scope: snapshot refresh proves render drift only. Install-time smoke is enforced separately by `pr-required-checks-chart.yaml` through `helm-install-smoke.yaml`.

--- a/scripts/test-detect-required-checks.sh
+++ b/scripts/test-detect-required-checks.sh
@@ -235,6 +235,16 @@ EOF
 	assert_not_contains "${rendered_wrapper}" "    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-snapshot-update.yaml@__BUILD_WORKFLOW_REF__"
 	assert_not_contains "${rendered_wrapper}" "__BUILD_WORKFLOW_REF__"
 	assert_contains "${rendered_wrapper}" "  group: caller-renovate-snapshot-update-\${{ github.workflow }}-\${{ github.ref }}"
+	assert_contains "${rendered_wrapper}" "      gh_app_client_id: \${{ secrets.GHCR_AUTO_CLIENT_ID }}"
+	assert_not_contains "${rendered_wrapper}" "      gh_app_id: \${{ secrets.GHCR_AUTO_APP_ID }}"
+
+	rendered_required_wrapper="${workspace}/jellyfin-helm/.github/workflows/pr-required-checks.yaml"
+	assert_contains "${rendered_required_wrapper}" "      gh_app_client_id: \${{ secrets.GHCR_AUTO_CLIENT_ID }}"
+	assert_not_contains "${rendered_required_wrapper}" "      gh_app_id: \${{ secrets.GHCR_AUTO_APP_ID }}"
+
+	rendered_lib_required_wrapper="${workspace}/helm-common-lib/.github/workflows/pr-required-checks.yaml"
+	assert_contains "${rendered_lib_required_wrapper}" "      gh_app_client_id: \${{ secrets.GHCR_AUTO_CLIENT_ID }}"
+	assert_not_contains "${rendered_lib_required_wrapper}" "      gh_app_id: \${{ secrets.GHCR_AUTO_APP_ID }}"
 )
 
 echo "detect-required-checks tests passed"

--- a/templates/app-chart/.github/workflows/pr-required-checks.yaml
+++ b/templates/app-chart/.github/workflows/pr-required-checks.yaml
@@ -37,5 +37,5 @@ jobs:
     with:
       chart_kind: app
     secrets:
-      gh_app_id: ${{ secrets.GHCR_AUTO_APP_ID }}
+      gh_app_client_id: ${{ secrets.GHCR_AUTO_CLIENT_ID }}
       gh_app_private_key: ${{ secrets.GHCR_AUTO_PKEY }}

--- a/templates/app-chart/.github/workflows/renovate-snapshot-update.yaml
+++ b/templates/app-chart/.github/workflows/renovate-snapshot-update.yaml
@@ -29,5 +29,5 @@ jobs:
     with:
       snapshots_dir: tests/snapshots
     secrets:
-      gh_app_id: ${{ secrets.GHCR_AUTO_APP_ID }}
+      gh_app_client_id: ${{ secrets.GHCR_AUTO_CLIENT_ID }}
       gh_app_private_key: ${{ secrets.GHCR_AUTO_PKEY }}

--- a/templates/helm-common-lib/.github/workflows/pr-required-checks.yaml
+++ b/templates/helm-common-lib/.github/workflows/pr-required-checks.yaml
@@ -37,5 +37,5 @@ jobs:
     with:
       chart_kind: lib
     secrets:
-      gh_app_id: ${{ secrets.GHCR_AUTO_APP_ID }}
+      gh_app_client_id: ${{ secrets.GHCR_AUTO_CLIENT_ID }}
       gh_app_private_key: ${{ secrets.GHCR_AUTO_PKEY }}


### PR DESCRIPTION
## Summary
- replace deprecated create-github-app-token app-id inputs with the client-id secret contract
- scope helper checkout tokens to build-workflow with contents read
- keep Renovate snapshot write-back scoped to the caller repo with contents write
- update scaffold templates, README, workflow matrix, and routing regression coverage

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh
- git -C build-workflow diff --check
- scripts/check-local-skill-policy.sh