### PR TITLE
docs: clarify phase 2 workflow contracts

### DIFF
--- a/.github/workflows/pr-required-checks.yaml
+++ b/.github/workflows/pr-required-checks.yaml
@@ -9,13 +9,6 @@ on:
       - ready_for_review
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'AGENTS.md'
-      - '.gitignore'
-      - '.editorconfig'
-      - 'LICENSE'
   merge_group:
     types:
       - checks_requested

--- a/README.md
+++ b/README.md
@@ -227,6 +227,11 @@ jobs:
       gh_app_private_key: ${{ secrets.GHCR_AUTO_PKEY }}
 ```
 
+Chart PR wrappers must pass the GitHub App client ID, not the App ID. The
+shared org secret contract is `GHCR_AUTO_CLIENT_ID` plus `GHCR_AUTO_PKEY`;
+reusable workflows scope helper checkout tokens to the minimum repository and
+permission needed by each step.
+
 ### 4. Add a Makefile for local development
 
 Create a `Makefile` in your chart repo:
@@ -349,6 +354,12 @@ make validate         # Run all 5 layers
 | `chart_path` | string | No | `.` | Path to the Helm chart directory |
 | `release_environment` | string | No | `production` | GitHub environment name used for release approvals/policies |
 | `enable_signing` | boolean | No | `true` | Enable keyless OCI signing/attestation |
+
+**Environment policy:** chart repos should pass `release_environment:
+production`, and the environment should be restricted to governed version tags
+before publishing. In this workspace the live `production` environments are
+restricted to `v*` tag deployments under the approved solo-maintainer
+exception.
 
 **How it works:**
 1. Verifies the caller is running from a version tag whose commit is reachable
@@ -476,7 +487,7 @@ wrapper.
 **Environment gate:** The `build-and-push` job requires the `toolchain-release`
 environment before publishing to GHCR.
 
-Published tags: `X.Y.Z`, `X.Y`, `X`.
+Published tags: `X.Y.Z`, `X.Y`, `X`, `vX.Y.Z`, and `latest`.
 
 ---
 

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -17,7 +17,7 @@ The GitHub wiki is disabled for this repository. Use this file and
 
 | Workflow | PR to `main` | Merge (`push` to `main`) | New tag (`v*`) | Manual (`workflow_dispatch`) | Reusable (`workflow_call`) |
 |---|---:|---:|---:|---:|---:|
-| `.github/workflows/pr-required-checks.yaml` | Yes (`opened/synchronize/reopened/ready_for_review`, with `paths-ignore`) | No | No | No | No |
+| `.github/workflows/pr-required-checks.yaml` | Yes (`opened/synchronize/reopened/ready_for_review`) | No | No | No | No |
 | `.github/workflows/quality-guardrails.yaml` | No (direct) | Yes (`paths` filtered) | No | No | Yes |
 | `.github/workflows/codeql.yaml` | No (direct) | Yes (`paths` filtered) | No | No | Yes |
 | `.github/workflows/dependency-review.yaml` | No (direct) | No | No | No | Yes |
@@ -47,7 +47,9 @@ Why it exists: single required status (`ci-required`) with path-aware fan-out.
 
 Notes:
 - Also runs on `merge_group` (`checks_requested`) for merge queue safety.
-- `paths-ignore` suppresses PR runs for docs-only/meta-only changes.
+- Docs-only and meta-only PRs still run the aggregate workflow so branch
+  protection receives `ci-required`; path detection skips the expensive child
+  jobs when no validation-relevant files changed.
 - PR fan-out is single-entry via this workflow; reusable child workflows do not self-trigger on PR.
 
 ### 2) `quality-guardrails.yaml`
@@ -103,6 +105,17 @@ Why it exists: publish `helm-validate` tool image.
 | `renovate-snapshot-update.yaml` | `update-snapshots` | Only when called in PR context for same-repo `renovate/*` branches from trusted Renovate automation actors; emits no-op or write-back evidence and fails on unexpected non-snapshot diffs or push failures. |
 
 ## Consumer Caller Contract Notes
+
+### Chart `pr-required-checks.yaml` wrapper
+
+- Secrets contract: the caller passes `GHCR_AUTO_CLIENT_ID` as
+  `gh_app_client_id` and `GHCR_AUTO_PKEY` as `gh_app_private_key`.
+- Token scope contract: helper checkout tokens minted by reusable workflows are
+  scoped to the specific helper or caller repository and requested permission,
+  not the full installation by owner only.
+- Environment contract: tag publish wrappers pass `release_environment:
+  production`; the live workspace policy restricts chart publish environments
+  to governed `v*` tags.
 
 ### App-chart `renovate-snapshot-update.yaml` wrapper
 


### PR DESCRIPTION
## Summary
- document the GHCR_AUTO_CLIENT_ID caller contract for chart PR wrappers
- document chart publish environment expectations for production
- correct the helm-validate image tag list to include vX.Y.Z and latest
- document token scope and release behavior in the trigger matrix
- keep the required-check aggregator running for docs-only PRs so branch protection receives ci-required while expensive child jobs remain path-filtered

## Validation
- make -C build-workflow lint
- build-workflow/scripts/test-detect-required-checks.sh
- git -C build-workflow diff --check
- scripts/check-local-skill-policy.sh