### PR TITLE
ci: keep chart required checks visible for docs PRs

### DIFF
--- a/.github/workflows/helm-install-smoke.yaml
+++ b/.github/workflows/helm-install-smoke.yaml
@@ -71,7 +71,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.34
+          ref: v0.1.35
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Install install-smoke toolchain

--- a/.github/workflows/helm-validate.yaml
+++ b/.github/workflows/helm-validate.yaml
@@ -82,7 +82,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     container:
-      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.34
+      image: ghcr.io/orhayoun-eevee/helm-validate:v0.1.35
     outputs:
       unit_test_files: ${{ steps.quality-metrics.outputs.unit_test_files }}
       unit_test_assertions: ${{ steps.quality-metrics.outputs.unit_test_assertions }}
@@ -111,7 +111,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.34
+          ref: v0.1.35
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Restore Helm caches

--- a/.github/workflows/pr-required-checks-chart.yaml
+++ b/.github/workflows/pr-required-checks-chart.yaml
@@ -53,7 +53,7 @@ jobs:
         with:
           repository: orhayoun-eevee/build-workflow
           path: .build-workflow
-          ref: v0.1.34
+          ref: v0.1.35
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Detect changed paths
@@ -73,7 +73,7 @@ jobs:
     if: github.event_name == 'pull_request' && (github.event.pull_request.head.repo.full_name == github.repository)
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/dependency-review.yaml@v0.1.35
 
   validate-app:
     if: inputs.chart_kind == 'app' && needs.detect-changes.outputs.run_validate == 'true'
@@ -81,7 +81,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.35
     with:
       chart_path: .
       kubernetes_version: '1.30.0'
@@ -105,7 +105,7 @@ jobs:
       - validate-app
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.35
     with:
       chart_path: .
       values_file: tests/scenarios/minimal.yaml
@@ -121,7 +121,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.35
     with:
       chart_path: libChart
       kubernetes_version: '1.30.0'
@@ -143,7 +143,7 @@ jobs:
     permissions:
       contents: read
       packages: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-validate.yaml@v0.1.35
     with:
       chart_path: test-chart
       kubernetes_version: '1.30.0'
@@ -167,7 +167,7 @@ jobs:
       - validate-test
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/helm-install-smoke.yaml@v0.1.35
     with:
       chart_path: test-chart
       values_file: tests/scenarios/minimal.yaml
@@ -182,7 +182,7 @@ jobs:
     if: needs.detect-changes.outputs.run_renovate_validation == 'true'
     permissions:
       contents: read
-    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.34
+    uses: orhayoun-eevee/build-workflow/.github/workflows/renovate-config.yaml@v0.1.35
 
   ci-required:
     name: ci-required

--- a/.github/workflows/renovate-snapshot-update.yaml
+++ b/.github/workflows/renovate-snapshot-update.yaml
@@ -22,7 +22,7 @@ permissions:
 
 env:
   BUILD_WORKFLOW_REPOSITORY: orhayoun-eevee/build-workflow
-  BUILD_WORKFLOW_REF: v0.1.34
+  BUILD_WORKFLOW_REF: v0.1.35
 
 concurrency:
   group: reusable-renovate-snapshot-update-${{ github.workflow }}-${{ github.ref }}

--- a/docs/workflow-trigger-matrix.md
+++ b/docs/workflow-trigger-matrix.md
@@ -1,6 +1,6 @@
 # Build-Workflow Trigger Matrix
 
-Last updated: 2026-05-27
+Last updated: 2026-05-28
 Repository: `orhayoun-eevee/build-workflow`
 
 The GitHub wiki is disabled for this repository. Use this file and
@@ -110,6 +110,11 @@ Why it exists: publish `helm-validate` tool image.
 
 - Secrets contract: the caller passes `GHCR_AUTO_CLIENT_ID` as
   `gh_app_client_id` and `GHCR_AUTO_PKEY` as `gh_app_private_key`.
+- Required-check trigger contract: chart wrappers must not use
+  `pull_request.paths-ignore`. Branch protection needs the required
+  `ci-required` status on every PR, including docs-only PRs; path-aware
+  short-circuiting belongs in `pr-required-checks-chart.yaml` through
+  `scripts/detect-required-checks.sh`.
 - Token scope contract: helper checkout tokens minted by reusable workflows are
   scoped to the specific helper or caller repository and requested permission,
   not the full installation by owner only.
@@ -138,7 +143,7 @@ Why it exists: publish `helm-validate` tool image.
 |---|---|
 | Open/update PR to `main` touching workflows/scripts/docker | `pr-required-checks` only as PR entrypoint (with selective child jobs: guardrails/docker-smoke/dependency-review/renovate/codeql), plus `detect-required-checks-tests` if relevant files changed. |
 | Merge PR to `main` | `quality-guardrails`, `codeql`, `detect-required-checks-tests`, `renovate-config` only if each workflow's `push.paths` match changed files. |
-| Push tag like `v0.1.34` | `docker-build` only, gated by `toolchain-release` (unless manually dispatching others). |
+| Push tag like `v0.1.35` | `docker-build` only, gated by `toolchain-release` (unless manually dispatching others). |
 
 ## Best-Practice Notes For Codex Context
 - Keep required PR gating centralized through `pr-required-checks.yaml` + `ci-required` aggregator.

--- a/scripts/test-detect-required-checks.sh
+++ b/scripts/test-detect-required-checks.sh
@@ -241,10 +241,12 @@ EOF
 	rendered_required_wrapper="${workspace}/jellyfin-helm/.github/workflows/pr-required-checks.yaml"
 	assert_contains "${rendered_required_wrapper}" "      gh_app_client_id: \${{ secrets.GHCR_AUTO_CLIENT_ID }}"
 	assert_not_contains "${rendered_required_wrapper}" "      gh_app_id: \${{ secrets.GHCR_AUTO_APP_ID }}"
+	assert_not_contains "${rendered_required_wrapper}" "    paths-ignore:"
 
 	rendered_lib_required_wrapper="${workspace}/helm-common-lib/.github/workflows/pr-required-checks.yaml"
 	assert_contains "${rendered_lib_required_wrapper}" "      gh_app_client_id: \${{ secrets.GHCR_AUTO_CLIENT_ID }}"
 	assert_not_contains "${rendered_lib_required_wrapper}" "      gh_app_id: \${{ secrets.GHCR_AUTO_APP_ID }}"
+	assert_not_contains "${rendered_lib_required_wrapper}" "    paths-ignore:"
 )
 
 echo "detect-required-checks tests passed"

--- a/templates/app-chart/.github/workflows/pr-required-checks.yaml
+++ b/templates/app-chart/.github/workflows/pr-required-checks.yaml
@@ -9,13 +9,6 @@ on:
       - ready_for_review
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'AGENTS.md'
-      - '.gitignore'
-      - '.editorconfig'
-      - 'LICENSE'
   merge_group:
     types:
       - checks_requested

--- a/templates/helm-common-lib/.github/workflows/pr-required-checks.yaml
+++ b/templates/helm-common-lib/.github/workflows/pr-required-checks.yaml
@@ -9,13 +9,6 @@ on:
       - ready_for_review
     branches:
       - main
-    paths-ignore:
-      - '**/*.md'
-      - 'docs/**'
-      - 'AGENTS.md'
-      - '.gitignore'
-      - '.editorconfig'
-      - 'LICENSE'
   merge_group:
     types:
       - checks_requested


### PR DESCRIPTION
## Summary
- remove paths-ignore from generated chart required-check wrappers so branch protection receives ci-required on docs-only PRs
- keep path-aware skipping inside the reusable detector and add scaffold regression assertions
- prepare build-workflow v0.1.35 self-references for release propagation

## Validation
- build-workflow/scripts/test-detect-required-checks.sh
- make -C build-workflow lint
- git -C build-workflow diff --check