### PR TITLE
ci: verify sha pinning enforcement

### DIFF
--- a/.github/sha-pinning-canary.md
+++ b/.github/sha-pinning-canary.md
@@ -1,0 +1,3 @@
+# SHA Pinning Canary
+
+Temporary PR-only file used to verify repository-level SHA pinning settings.


### PR DESCRIPTION
Temporary canary PR to verify repository-level SHA pinning enforcement. Do not merge.